### PR TITLE
Accept or deny

### DIFF
--- a/contracts/src/main/kotlin/com/template/contracts/AcceptAppointmentContract.kt
+++ b/contracts/src/main/kotlin/com/template/contracts/AcceptAppointmentContract.kt
@@ -27,7 +27,7 @@ class AppointmentContract : Contract {
         }
     }
     interface Commands : CommandData {
-        class Create : AppointmentContract.Commands
+        class Create : Commands
     }
 
 }

--- a/contracts/src/main/kotlin/com/template/contracts/AppointmentDateContract.kt
+++ b/contracts/src/main/kotlin/com/template/contracts/AppointmentDateContract.kt
@@ -26,18 +26,28 @@ class AppointmentDateContract : Contract {
     }
 
     override fun verify(tx: LedgerTransaction) {
-        requireThat {
-            "No inputs should be consumed when issuing a date" using (tx.inputs.isEmpty())
-            "Only one output state is created" using (tx.outputs.size == 1)
+        val command = tx.findCommand<Commands> { true }
+        when (command.value) {
+            is Commands.Create -> {
+                requireThat {
+                    "No inputs should be consumed when issuing a date" using (tx.inputs.isEmpty())
+                    "Only one output state is created" using (tx.outputs.size == 1)
 
-            val out = tx.outputStates[0] as AvailableAppointmentDate
-            "Dates must be of the format dd-MM-yyyy" using (checkDate(out.date))
+                    val out = tx.outputStates[0] as AvailableAppointmentDate
+                    "Dates must be of the format dd-MM-yyyy" using (checkDate(out.date))
+                }
+            }
 
-
+            is Commands.Consume -> {
+                requireThat {
+                    // do nothing for now
+                }
+            }
         }
     }
     interface Commands : CommandData {
-        class Create : AppointmentDateContract.Commands
+        class Create : Commands
+        class Consume : Commands
     }
 
 }

--- a/contracts/src/main/kotlin/com/template/contracts/AppointmentRequestContract.kt
+++ b/contracts/src/main/kotlin/com/template/contracts/AppointmentRequestContract.kt
@@ -42,7 +42,7 @@ class AppointmentRequestContract : Contract {
             }
             is Commands.Accept -> {
                 requireThat {
-                    "2 inputs should be consumed when accepting a request" using (tx.inputs.size == 1)
+                    "2 inputs should be consumed when accepting a request" using (tx.inputs.size == 2)
                     "1 Output state is created" using (tx.outputs.size == 1)
                 }
             }

--- a/contracts/src/main/kotlin/com/template/states/AvailableAppointmentDate.kt
+++ b/contracts/src/main/kotlin/com/template/states/AvailableAppointmentDate.kt
@@ -16,14 +16,13 @@ import java.lang.IllegalStateException
 @BelongsToContract(AppointmentDateContract::class)
 data class AvailableAppointmentDate(val date: String,
                                     val doctor: Party,
-                                    val alice: Party,
-                                    val bob: Party,
-                                    override val participants: List<AbstractParty> = listOf(doctor, bob, alice)
+                                    val patientList: List<Party>,
+                                    override val participants: List<AbstractParty> = (patientList + doctor)
 ) : QueryableState {
     override fun generateMappedObject(schema: MappedSchema): PersistentState {
         return when (schema) {
             is AppointmentDateSchemaV1 -> AppointmentDateSchemaV1.AvailableDate(
-                date = this.date.toString()
+                date = this.date
             )
             else -> throw IllegalStateException("Unrecognized schema ${schema.name} passed.")
         }

--- a/workflows/src/main/kotlin/com/template/flows/ApproveAppointmentRequest.kt
+++ b/workflows/src/main/kotlin/com/template/flows/ApproveAppointmentRequest.kt
@@ -17,6 +17,9 @@ import net.corda.core.flows.FlowSession
 import net.corda.core.identity.Party
 
 import com.template.states.Appointment
+import com.template.states.AppointmentRequest
+import com.template.states.AvailableAppointmentDate
+import net.corda.core.contracts.StateAndRef
 
 import net.corda.core.transactions.TransactionBuilder
 
@@ -31,7 +34,9 @@ import java.util.*
 @InitiatingFlow
 @StartableByRPC
 class ApproveAppointmentRequest(private val alice: Party,
-                                private val date: String) : FlowLogic<SignedTransaction>() {
+                                private val date: String,
+                                private val availableDate: StateAndRef<AvailableAppointmentDate>,
+                                private val request: StateAndRef<AppointmentRequest>) : FlowLogic<SignedTransaction>() {
     override val progressTracker = ProgressTracker()
 
     @Suspendable
@@ -52,7 +57,9 @@ class ApproveAppointmentRequest(private val alice: Party,
 
         // Step 3. Create a new TransactionBuilder object.
         val builder = TransactionBuilder(notary)
-                .addCommand(AppointmentContract.Commands.Create(), listOf(doctor.owningKey, alice.owningKey))
+                .addCommand(AppointmentContract.Commands.Create(), listOf(doctor.owningKey))
+                .addInputState(availableDate)
+                .addInputState(request)
                 .addOutputState(output)
 
         // Step 4. Verify and sign it with our KeyPair.

--- a/workflows/src/main/kotlin/com/template/flows/ApproveAppointmentRequest.kt
+++ b/workflows/src/main/kotlin/com/template/flows/ApproveAppointmentRequest.kt
@@ -76,10 +76,8 @@ class ApproveAppointmentRequest(private val alice: Party,
         otherParties.remove(ourIdentity)
         val sessions = otherParties.stream().map { el: Party? -> initiateFlow(el!!) }.collect(Collectors.toList())
 
-        val stx = subFlow(CollectSignaturesFlow(ptx, sessions))
-
         // Step 7. Assuming no exceptions, we can now finalise the transaction
-        return subFlow<SignedTransaction>(FinalityFlow(stx, sessions))
+        return subFlow<SignedTransaction>(FinalityFlow(ptx, sessions))
     }
 }
 
@@ -87,14 +85,7 @@ class ApproveAppointmentRequest(private val alice: Party,
 class ApprovalResponder(val counterpartySession: FlowSession) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call(): SignedTransaction {
-        val signTransactionFlow = object : SignTransactionFlow(counterpartySession) {
-            override fun checkTransaction(stx: SignedTransaction) = requireThat {
-                //Addition checks
-                //TODO think about what checks can be done here
-            }
-        }
-        val txId = subFlow(signTransactionFlow).id
-        return subFlow(ReceiveFinalityFlow(counterpartySession, expectedTxId = txId))
+        return subFlow(ReceiveFinalityFlow(counterpartySession))
     }
 }
 

--- a/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
+++ b/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
@@ -3,6 +3,7 @@ package com.template.flows
 import co.paralleluniverse.fibers.Suspendable
 import com.template.contracts.AppointmentContract
 import com.template.states.Appointment
+import com.template.states.AppointmentRequest
 import net.corda.core.contracts.StateAndRef
 import net.corda.core.contracts.requireThat
 import net.corda.core.flows.*
@@ -21,7 +22,8 @@ import java.util.stream.Collectors
 @InitiatingFlow
 @StartableByRPC
 class DenyAppointmentRequest(private val alice: Party,
-                             private val date: String) : FlowLogic<SignedTransaction>() {
+                             private val date: String,
+                             private val request: StateAndRef<AppointmentRequest>) : FlowLogic<SignedTransaction>() {
     override val progressTracker = ProgressTracker()
 
     @Suspendable
@@ -38,7 +40,8 @@ class DenyAppointmentRequest(private val alice: Party,
 
         // Step 3. Create a new TransactionBuilder object.
         val builder = TransactionBuilder(notary)
-                .addCommand(AppointmentContract.Commands.Create(), listOf(doctor.owningKey, alice.owningKey))
+                        .addInputState(request)
+                        .addCommand(AppointmentContract.Commands.Create(), listOf(doctor.owningKey))
 
 
         // Step 4. Verify and sign it with our KeyPair.

--- a/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
+++ b/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
@@ -50,11 +50,11 @@ class DenyAppointmentRequest(private val alice: Party,
         val ptx = serviceHub.signInitialTransaction(builder)
 
         // Step 6. Collect the other party's signature using the SignTransactionFlow.
-        val otherParties: MutableList<Party> = listOf(alice).stream().map { el: AbstractParty? -> el as Party? }.collect(Collectors.toList())
+        val otherParties: MutableList<Party> = mutableListOf(alice)
         val sessions = otherParties.stream().map { el: Party? -> initiateFlow(el!!) }.collect(Collectors.toList())
 
         // Step 7. Assuming no exceptions, we can now finalise the transaction
-        return subFlow<SignedTransaction>(FinalityFlow(ptx, sessions))
+        return subFlow(FinalityFlow(ptx, sessions))
     }
 
 }

--- a/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
+++ b/workflows/src/main/kotlin/com/template/flows/DenyAppointmentRequest.kt
@@ -38,7 +38,8 @@ class DenyAppointmentRequest(private val alice: Party,
         //Compose the State that carries the appointment information
 
 
-        // Step 3. Create a new TransactionBuilder object.
+        // Step 3. Create a new TransactionBuilder object. The request is going to be consumed, but the availableDate will
+        //         continue to be available
         val builder = TransactionBuilder(notary)
                         .addInputState(request)
                         .addCommand(AppointmentContract.Commands.Create(), listOf(doctor.owningKey))

--- a/workflows/src/test/kotlin/com/template/AppointmentRequestTests.kt
+++ b/workflows/src/test/kotlin/com/template/AppointmentRequestTests.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.Future
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 import com.template.states.AvailableAppointmentDate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.Builder.equal
 import net.corda.core.utilities.getOrThrow
@@ -23,6 +24,7 @@ class AppointmentRequestTests {
     private lateinit var doctor: StartedMockNode
     private lateinit var alice: StartedMockNode
     private lateinit var bob: StartedMockNode
+    private lateinit var patientList: List<Party>
 
     @Before
     fun setup() {
@@ -35,6 +37,7 @@ class AppointmentRequestTests {
         doctor = network.createPartyNode()
         alice = network.createPartyNode()
         bob = network.createPartyNode()
+        patientList = listOf(alice.info.legalIdentities[0], bob.info.legalIdentities[0])
         network.runNetwork()
     }
 
@@ -44,7 +47,7 @@ class AppointmentRequestTests {
     }
     @Test
     fun requestAppointmentTest() {
-        val availableDateFlow = CreateAppointmentDate(alice.info.legalIdentities[0], bob.info.legalIdentities[0], "06-07-2021")
+        val availableDateFlow = CreateAppointmentDate(patientList, "06-07-2021")
         val future1 = doctor.startFlow(availableDateFlow)
 
         network.runNetwork()

--- a/workflows/src/test/kotlin/com/template/MockNetworkTests.kt
+++ b/workflows/src/test/kotlin/com/template/MockNetworkTests.kt
@@ -3,6 +3,7 @@ package com.template
 import com.template.flows.CreateAppointmentDate
 import com.template.flows.CreateDateResponder
 import net.corda.core.identity.CordaX500Name
+import net.corda.core.utilities.getOrThrow
 import net.corda.testing.internal.chooseIdentityAndCert
 import net.corda.testing.node.*
 import org.junit.After
@@ -36,17 +37,17 @@ class MockNetworkTests {
 
     @Test
     fun flowReturnsCorrectState() {
-        val doc = nodeD.info.chooseIdentityAndCert().party
         val alice = nodeA.info.chooseIdentityAndCert().party
         val bob = nodeB.info.chooseIdentityAndCert().party
 
+        val patientList = listOf(alice, bob)
+
         println("found parties")
 
-        val flow = CreateAppointmentDate(alice,bob,"16-01-2000")
+        val flow = CreateAppointmentDate(patientList,"16-01-2000")
         val future = nodeD.startFlow(flow)
         mockNet.runNetwork()
-
-        println("date correct")
+        future.getOrThrow()
     }
 
     @After

--- a/workflows/src/test/kotlin/com/template/ResponseTests.kt
+++ b/workflows/src/test/kotlin/com/template/ResponseTests.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.Future
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.transactions.SignedTransaction
 import com.template.states.AvailableAppointmentDate
+import net.corda.core.identity.Party
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.Builder.equal
 import net.corda.core.utilities.getOrThrow
@@ -27,6 +28,7 @@ class ResponseTests {
     private lateinit var doctor: StartedMockNode
     private lateinit var alice: StartedMockNode
     private lateinit var bob: StartedMockNode
+    private lateinit var patientList: List<Party>
 
     @Before
     fun setup() {
@@ -39,6 +41,7 @@ class ResponseTests {
         doctor = network.createPartyNode()
         alice = network.createPartyNode()
         bob = network.createPartyNode()
+        patientList = listOf(bob.info.legalIdentities[0], alice.info.legalIdentities[0])
         network.runNetwork()
     }
 
@@ -48,7 +51,7 @@ class ResponseTests {
     }
     @Test
     fun approveRequest() {
-        val availableDateFlow = CreateAppointmentDate(alice.info.legalIdentities[0], bob.info.legalIdentities[0], "06-07-2021")
+        val availableDateFlow = CreateAppointmentDate(patientList, "06-07-2021")
         val future1 = doctor.startFlow(availableDateFlow)
 
         network.runNetwork()
@@ -67,7 +70,7 @@ class ResponseTests {
         future.getOrThrow()
 
         val approvalFlow = ApproveAppointmentRequest(alice.info.legalIdentities[0],
-            bob.info.legalIdentities[0],
+            mutableListOf(bob.info.legalIdentities[0]),
             "06-07-2021",
             appointmentDate,
             appointmentRequest)
@@ -86,7 +89,7 @@ class ResponseTests {
 
     @Test
     fun denyRequest() {
-        val availableDateFlow = CreateAppointmentDate(alice.info.legalIdentities[0], bob.info.legalIdentities[0], "06-07-2021")
+        val availableDateFlow = CreateAppointmentDate(patientList, "06-07-2021")
         val future1 = doctor.startFlow(availableDateFlow)
 
         network.runNetwork()

--- a/workflows/src/test/kotlin/com/template/ResponseTests.kt
+++ b/workflows/src/test/kotlin/com/template/ResponseTests.kt
@@ -1,0 +1,77 @@
+package com.template
+
+import com.template.flows.ApproveAppointmentRequest
+import com.template.flows.CreateAppointmentDate
+import com.template.flows.CreateAppointmentRequest
+import com.template.schemas.AppointmentDateSchemaV1
+import com.template.states.AppointmentRequest
+import net.corda.testing.node.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.Future
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.transactions.SignedTransaction
+import com.template.states.AvailableAppointmentDate
+import net.corda.core.node.services.Vault
+import net.corda.core.node.services.vault.Builder.equal
+import net.corda.core.utilities.getOrThrow
+import net.corda.testing.common.internal.testNetworkParameters
+import java.util.*
+
+
+class ResponseTests {
+    private lateinit var network: MockNetwork
+    private lateinit var doctor: StartedMockNode
+    private lateinit var alice: StartedMockNode
+    private lateinit var bob: StartedMockNode
+
+    @Before
+    fun setup() {
+        val myNetworkParameters = testNetworkParameters(minimumPlatformVersion = 4)
+        network = MockNetwork(MockNetworkParameters(cordappsForAllNodes = listOf(
+            TestCordapp.findCordapp("com.template.contracts"),
+            TestCordapp.findCordapp("com.template.flows")
+        ),
+            networkParameters = myNetworkParameters))
+        doctor = network.createPartyNode()
+        alice = network.createPartyNode()
+        bob = network.createPartyNode()
+        network.runNetwork()
+    }
+
+    @After
+    fun tearDown() {
+        network.stopNodes()
+    }
+    @Test
+    fun approveRequest() {
+        val availableDateFlow = CreateAppointmentDate(alice.info.legalIdentities[0], bob.info.legalIdentities[0], "06-07-2021")
+        val future1 = doctor.startFlow(availableDateFlow)
+
+        network.runNetwork()
+        future1.getOrThrow()
+
+        val dateAttribute = AppointmentDateSchemaV1.AvailableDate::date.equal("06-07-2021")
+        val customCriteria = QueryCriteria.VaultCustomQueryCriteria(dateAttribute)
+        val appointmentDate = alice.services.vaultService.queryBy(AvailableAppointmentDate::class.java, customCriteria).states[0]
+
+        // should try to run a vault query to see if the appointment request state was in fact created
+        val flow = CreateAppointmentRequest(doctor.info.legalIdentities[0], "06-07-2021", appointmentDate)
+        val future: Future<SignedTransaction> = alice.startFlow(flow)
+        network.runNetwork()
+        val inputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.UNCONSUMED)
+        val appointmentRequest = alice.services.vaultService.queryBy(AppointmentRequest::class.java, inputCriteria).states[0]
+        future.getOrThrow()
+
+        val approvalFlow = ApproveAppointmentRequest(alice.info.legalIdentities[0],
+            bob.info.legalIdentities[0],
+            "06-07-2021",
+            appointmentDate,
+            appointmentRequest)
+        val approvalFuture = doctor.startFlow(approvalFlow)
+        network.runNetwork()
+        approvalFuture.getOrThrow()
+
+    }
+}

--- a/workflows/src/test/kotlin/com/template/ResponseTests.kt
+++ b/workflows/src/test/kotlin/com/template/ResponseTests.kt
@@ -3,6 +3,7 @@ package com.template
 import com.template.flows.ApproveAppointmentRequest
 import com.template.flows.CreateAppointmentDate
 import com.template.flows.CreateAppointmentRequest
+import com.template.flows.DenyAppointmentRequest
 import com.template.schemas.AppointmentDateSchemaV1
 import com.template.states.AppointmentRequest
 import net.corda.testing.node.*
@@ -18,6 +19,7 @@ import net.corda.core.node.services.vault.Builder.equal
 import net.corda.core.utilities.getOrThrow
 import net.corda.testing.common.internal.testNetworkParameters
 import java.util.*
+import kotlin.test.assertEquals
 
 
 class ResponseTests {
@@ -72,6 +74,48 @@ class ResponseTests {
         val approvalFuture = doctor.startFlow(approvalFlow)
         network.runNetwork()
         approvalFuture.getOrThrow()
+
+        val consumedCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.CONSUMED)
+        val consumedDate = alice.services.vaultService.queryBy(AppointmentRequest::class.java, consumedCriteria).states
+        val consumedReq = alice.services.vaultService.queryBy(AppointmentRequest::class.java, consumedCriteria).states
+
+        assertEquals(1, consumedDate.size, "date not consumed")
+        assertEquals(1, consumedReq.size, "request not consumed")
+
+    }
+
+    @Test
+    fun denyRequest() {
+        val availableDateFlow = CreateAppointmentDate(alice.info.legalIdentities[0], bob.info.legalIdentities[0], "06-07-2021")
+        val future1 = doctor.startFlow(availableDateFlow)
+
+        network.runNetwork()
+        future1.getOrThrow()
+
+        val dateAttribute = AppointmentDateSchemaV1.AvailableDate::date.equal("06-07-2021")
+        val customCriteria = QueryCriteria.VaultCustomQueryCriteria(dateAttribute)
+        val appointmentDate = alice.services.vaultService.queryBy(AvailableAppointmentDate::class.java, customCriteria).states[0]
+
+        // should try to run a vault query to see if the appointment request state was in fact created
+        val flow = CreateAppointmentRequest(doctor.info.legalIdentities[0], "06-07-2021", appointmentDate)
+        val future: Future<SignedTransaction> = alice.startFlow(flow)
+        network.runNetwork()
+        val inputCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.UNCONSUMED)
+        val appointmentRequest = alice.services.vaultService.queryBy(AppointmentRequest::class.java, inputCriteria).states[0]
+        future.getOrThrow()
+
+        val denyingFlow = DenyAppointmentRequest(alice.info.legalIdentities[0],
+            appointmentRequest)
+        val denyingFuture = doctor.startFlow(denyingFlow)
+        network.runNetwork()
+        denyingFuture.getOrThrow()
+
+        val consumedCriteria: QueryCriteria = QueryCriteria.VaultQueryCriteria().withStatus(Vault.StateStatus.CONSUMED)
+        val unconsumedDate = alice.services.vaultService.queryBy(AvailableAppointmentDate::class.java, inputCriteria).states
+        val consumedReq = alice.services.vaultService.queryBy(AppointmentRequest::class.java, consumedCriteria).states
+
+        assertEquals(1, unconsumedDate.size, "date consumed")
+        assertEquals(1, consumedReq.size, "request not consumed")
 
     }
 }


### PR DESCRIPTION
- Add the flows to accept and deny requests from patients. The doctor will make the decision and the patients will be notified. 
- In case of a denial, only the Request state is going to be consumed, and the available date will still be available.
- In case of acceptance, both the request and the available date will be consumed. 
- Add tests for these flows.